### PR TITLE
Allow setting dlproto version manually to prevent duplicated stream IDs

### DIFF
--- a/src/simpledali/abstractdali.py
+++ b/src/simpledali/abstractdali.py
@@ -26,14 +26,14 @@ QUERY_MODE="query"
 STREAM_MODE="stream"
 
 class DataLink(ABC):
-    def __init__(self, packet_size=-1, verbose=False):
+    def __init__(self, packet_size=-1, dlproto=DLPROTO_1_0, verbose=False):
         """init DataLink. Packet_size and dlproto can be set,
         or can be acquired from the
         server via the capabilities response within id()
         """
         self.__mode = QUERY_MODE
         self.packet_size = packet_size
-        self.dlproto = "1.0"
+        self.dlproto = dlproto
         self.verbose = verbose
         self.token = None
         self.int_types = [


### PR DESCRIPTION
Context: When setting up a server with all the new protocols, I sometimes wasn't calling id(), so the version was iterating between 1.0 and 1.1.

This in turn was randomly changing the stream IDs to the previous version without FDSN:
https://github.com/crotwell/simpledali/blob/990cf7431c713a6e555dbd4b4ae40faa56f6b59a/src/simpledali/abstractdali.py#L158-L159
And that had the effect of creating duplicated and independent streams in ringserver.

So for newer servers, out of caution I'd recommend setting the version manually instead of relying on the id command.

Also, thanks @crotwell for so many awesome libraries! They really make programming these a breeze! :)